### PR TITLE
Resolve unused variable 'ret'

### DIFF
--- a/user/printf.c
+++ b/user/printf.c
@@ -195,7 +195,7 @@ printf(const char* fmt, ...)
 
   va_start(va, fmt);
   char buffer[1];
-  const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, fmt, va, 0);
+  _vsnprintf(_out_char, buffer, (size_t)-1, fmt, va, 0);
   va_end(va);
   return;
 }


### PR DESCRIPTION
- `TARGET=arm make qemu` 실행시 발생하는 아래 에러를 수정하는 PR입니다.
```
user/printf.c: In function 'printf':
user/printf.c:198:13: error: unused variable 'ret' [-Werror=unused-variable]
  198 |   const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, fmt, va, 0);
      |             ^~~
cc1: all warnings being treated as errors
```
- 이 PR이 머지되면 `lat_pipe`도 잘 실행됩니다.
```
$ lat_pipe
Pipe latency: 780.6941 microseconds
```