### PR TITLE
fix lat_proc shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,7 @@ UPROGS=\
 	$U/_zombie\
 	# $U/_lat_syscall\
 	$U/_lat_proc\
+	$U/_hello\
 	$U/_lat_pipe\
 	$U/_lat_ctx\
 	$U/_lat_fs\

--- a/user/sh.c
+++ b/user/sh.c
@@ -141,8 +141,23 @@ getcmd(char *buf, int nbuf)
   return 0;
 }
 
+void
+runstring(char *buf)
+{
+  if(buf[0] == 'c' && buf[1] == 'd' && buf[2] == ' '){
+    // Chdir must be called by the parent, not the child.
+    buf[strlen(buf)-1] = 0;  // chop \n
+    if(chdir(buf+3) < 0)
+      fprintf(2, "cannot cd %s\n", buf+3);
+    return;
+  }
+  if(fork1() == 0)
+    runcmd(parsecmd(buf));
+  wait(0);
+}
+
 int
-main(void)
+main(int argc, char *argv[])
 {
   static char buf[100];
   int fd;
@@ -155,19 +170,14 @@ main(void)
     }
   }
 
-  // Read and run input commands.
-  while(getcmd(buf, sizeof(buf)) >= 0){
-    if(buf[0] == 'c' && buf[1] == 'd' && buf[2] == ' '){
-      // Chdir must be called by the parent, not the child.
-      buf[strlen(buf)-1] = 0;  // chop \n
-      if(chdir(buf+3) < 0)
-        fprintf(2, "cannot cd %s\n", buf+3);
-      continue;
-    }
-    if(fork1() == 0)
-      runcmd(parsecmd(buf));
-    wait(0);
+  if (argc > 2 && argv[1][0] == '-' && argv[1][1] == 'c') {
+    runstring(argv[2]);
+    exit(0);
   }
+
+  // Read and run input commands.
+  while(getcmd(buf, sizeof(buf)) >= 0)
+    runstring(buf);
   exit(0);
 }
 


### PR DESCRIPTION
* lat_proc shell이 간신히 돌아갈 정도로만 user/sh.c를 편집했습니다.
* lat_proc을 돌릴때는 hello도 컴파일해야하는 것으로 보여, Makefile 주석에 추가했습니다.

> $ lat_proc exec
>Process fork+execve: 4680.8468 microseconds

> $ lat_proc shell
> Process fork+/bin/sh -c: 3399.4306 microseconds